### PR TITLE
Simplify navigation node definition types

### DIFF
--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -56,7 +56,7 @@ export type {
   PanelOpenerChildDefinition,
   StandardNodeDefinition,
   RootNodeDefinition,
-  RootNodePanelOpenerDefinition,
+  PanelOpenerNodeDefinition,
   CloudLinkId,
   CloudLink,
   CloudLinks,

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -53,7 +53,7 @@ export type { ChromeBadge, ChromeBreadcrumbsBadge, ChromeUserBanner, ChromeStyle
 
 export type {
   ChromeProjectNavigationNode,
-  RootNodePanelOpenerDefinition,
+  PanelOpenerNodeDefinition,
   PanelOpenerChildDefinition,
   StandardNodeDefinition,
   RootNodeDefinition,

--- a/src/core/packages/chrome/browser/src/project_navigation.ts
+++ b/src/core/packages/chrome/browser/src/project_navigation.ts
@@ -207,10 +207,7 @@ export type StandardNodeDefinition<
   renderAs?: never;
   children?: Array<
     | StandardNodeDefinition<LinkId, ChildrenId, ChildrenId>
-    | (NodeDefinitionCommon<LinkId, Id> & {
-        renderAs: 'panelOpener';
-        children?: Array<StandardNodeDefinition<LinkId, ChildrenId>>;
-      })
+    | PanelOpenerNodeDefinition<LinkId, ChildrenId, ChildrenId>
   >;
 };
 
@@ -220,7 +217,8 @@ export type PanelOpenerChildDefinition<
   Id extends string = string
 > = StandardNodeDefinition<LinkId, Id, Id>;
 
-export type RootNodePanelOpenerDefinition<
+/** A node that opens a flyout panel. Valid both at the root and nested under a standard node. */
+export type PanelOpenerNodeDefinition<
   LinkId extends AppDeepLinkId = AppDeepLinkId,
   Id extends string = string,
   ChildrenId extends string = Id
@@ -240,7 +238,7 @@ export type RootNodeDefinition<
       renderAs: 'home';
       children?: never;
     })
-  | RootNodePanelOpenerDefinition<LinkId, Id, ChildrenId>;
+  | PanelOpenerNodeDefinition<LinkId, Id, ChildrenId>;
 
 /**
  * @public

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.test.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.test.ts
@@ -6,14 +6,14 @@
  */
 
 import { createNavigationTree, filterForFeatureAvailability } from './navigation_tree';
-import type { NavigationTreeDefinition, NodeDefinition } from '@kbn/core-chrome-browser';
+import type { NodeDefinition } from '@kbn/core-chrome-browser';
 import type { CoreStart } from '@kbn/core/public';
 import { coreMock } from '@kbn/core/public/mocks';
 
 const getAdminSettingsNode = (
   options: Parameters<typeof createNavigationTree>[0]
 ): NodeDefinition => {
-  const { footer } = createNavigationTree(options) as NavigationTreeDefinition;
+  const { footer } = createNavigationTree(options);
   const adminSettingsNode = footer?.find((item) => item.id === 'admin_and_settings');
 
   if (!adminSettingsNode) {
@@ -43,7 +43,7 @@ describe('Navigation Tree', () => {
   });
 
   it('lists Manage jobs to Stack Management anomaly detection jobs first under ML anomaly detection nav', () => {
-    const { body } = createNavigationTree({ core }) as NavigationTreeDefinition;
+    const { body } = createNavigationTree({ core });
     const mlNode = body.find((item) => item.id === 'machine_learning-landing');
     const anomalySection = mlNode?.children?.find(
       (item) => item.id === 'category-anomaly_detection'
@@ -70,7 +70,7 @@ describe('Navigation Tree', () => {
   });
 
   it('shows AI Assistant and hides Agents when AI Assistant is enabled', () => {
-    const { body } = createNavigationTree({ core }) as NavigationTreeDefinition;
+    const { body } = createNavigationTree({ core });
 
     const aiAssistantNode = body.find((item) => item.link === 'observabilityAIAssistant');
     const agentsNode = body.find((item) => item.link === 'agent_builder');
@@ -83,7 +83,7 @@ describe('Navigation Tree', () => {
     const { body } = createNavigationTree({
       core,
       showAiAssistant: false,
-    }) as NavigationTreeDefinition;
+    });
 
     const aiAssistantNode = body.find((item) => item.link === 'observabilityAIAssistant');
     const agentsNode = body.find((item) => item.link === 'agent_builder');
@@ -120,7 +120,7 @@ describe('Navigation Tree', () => {
   it('uses a single Alerts link to classic Observability alerts even when alerting v2 is enabled', () => {
     core.settings.globalClient.get = <T>(_key: string) => true as T;
 
-    const { body } = createNavigationTree({ core }) as NavigationTreeDefinition;
+    const { body } = createNavigationTree({ core });
     const alertsPanel = body.find(
       (item) => 'id' in item && item.id === 'alerting' && item.renderAs === 'panelOpener'
     );
@@ -136,7 +136,7 @@ describe('Navigation Tree', () => {
   });
 
   it('includes Data Federation under Data management > Indices and data streams', () => {
-    const { footer } = createNavigationTree({ core }) as NavigationTreeDefinition;
+    const { footer } = createNavigationTree({ core });
     const dataManagement = footer?.find((item: any) => item.title === 'Data management');
     const indicesSection = dataManagement?.children?.find((item: any) => {
       return (

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/alert_detections_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/alert_detections_navigation_tree.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { RootNodePanelOpenerDefinition } from '@kbn/core-chrome-browser';
+import type { PanelOpenerNodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityPageName, SecurityGroupName } from '../constants';
 import { SecurityLinkGroup } from '../link_groups';
 import { securityLink } from '../links';
 import { i18nStrings } from '../i18n_strings';
 
-export const createAlertDetectionsNavigationTree = (): RootNodePanelOpenerDefinition => ({
+export const createAlertDetectionsNavigationTree = (): PanelOpenerNodeDefinition => ({
   id: SecurityGroupName.alertDetections,
   title: SecurityLinkGroup[SecurityGroupName.alertDetections].title,
   icon: 'warning',

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/rules_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/rules_navigation_tree.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { RootNodePanelOpenerDefinition } from '@kbn/core-chrome-browser';
+import type { PanelOpenerNodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityPageName, SecurityGroupName } from '../constants';
 import { SecurityLinkGroup } from '../link_groups';
 import { securityLink } from '../links';
 import { i18nStrings } from '../i18n_strings';
 
-export const createRulesNavigationTree = (): RootNodePanelOpenerDefinition => ({
+export const createRulesNavigationTree = (): PanelOpenerNodeDefinition => ({
   id: SecurityGroupName.rules,
   title: SecurityLinkGroup[SecurityGroupName.rules].title,
   icon: 'radar',

--- a/x-pack/solutions/security/plugins/security_solution/public/app/links/deep_links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/links/deep_links.ts
@@ -9,12 +9,7 @@ import type { Subject, Subscription } from 'rxjs';
 import { combineLatestWith, debounceTime } from 'rxjs';
 import type { AppDeepLink, AppUpdater, AppDeepLinkLocations } from '@kbn/core/public';
 import type { SecurityPageName } from '@kbn/deeplinks-security';
-import type {
-  NavigationTreeDefinition,
-  NodeDefinition,
-  PanelOpenerChildDefinition,
-  StandardNodeDefinition,
-} from '@kbn/core-chrome-browser';
+import type { NavigationTreeDefinition, NodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityLinkGroup } from '@kbn/security-solution-navigation/links';
 import type { SecurityGroupName } from '@kbn/security-solution-navigation';
 import type { AppLinkItems, LinkItem, NormalizedLinks } from '../../common/links/types';
@@ -67,10 +62,8 @@ export const solutionFormatter = (
   return solutionNodesFormatter(nodes, normalizedLinks);
 };
 
-type SolutionNavNode = NodeDefinition | PanelOpenerChildDefinition | StandardNodeDefinition;
-
 const solutionNodesFormatter = (
-  navigationNodes: SolutionNavNode[],
+  navigationNodes: NodeDefinition[],
   normalizedLinks: NormalizedLinks
 ): AppDeepLink[] => {
   const deepLinks: AppDeepLink[] = [];


### PR DESCRIPTION
Follow-up on top of #276729, addressing a few simplification/naming points from review.

## Summary

- Reuse a single `PanelOpenerNodeDefinition` for both root-level and nested panel openers instead of hand-spelling the shape inline inside `StandardNodeDefinition.children`. Renamed from `RootNodePanelOpenerDefinition` because the shape isn't root-specific. This also fixes the nested opener threading the parent's `Id` id-space instead of `ChildrenId` (matching its sibling standard nodes).
- Collapse the redundant `SolutionNavNode` union in security `deep_links.ts` to `NodeDefinition` — the other two members (`StandardNodeDefinition`, `PanelOpenerChildDefinition`) are already subtypes.
- Drop the redundant `as NavigationTreeDefinition` casts in the serverless observability nav tree test; `createNavigationTree` already returns that type.

Type-checked: `@kbn/core-chrome-browser`, security navigation package, `serverless_observability`, and `security_solution` all pass.